### PR TITLE
subDT ceil -> round

### DIFF
--- a/fdmt/cpu_fdmt.py
+++ b/fdmt/cpu_fdmt.py
@@ -44,7 +44,7 @@ class FDMT:
             dF = self.df
         loc = f**-2 - (f + dF) ** -2
         glo = self.fmin**-2 - self.fmax**-2
-        return np.ceil((self.maxDT - 1) * loc / glo).astype(int) + 1
+        return np.round(self.maxDT * loc / glo).astype(int)
 
 
     def buildAB(self, numCols, dtype=np.uint32):


### PR DESCRIPTION
I have no idea why subDT had the previous form. It's very possible there is an excellent reason of which I am unaware.  

But as is if you do `subDT(fs)` the sum overestimates `maxDT`. I don't believe we want this to be the case.  `subDT` is supposed to give the shift of one channel relative to the next in order to give a total of `maxDT` over the entire band. Therefore we want the sum of the individual shifts to be as close to maxDT as possible. `np.round` will sometimes overestimate it, but by much, much less.

e.g. I just tried it for a setup with `maxDT=16392` and got:  
current subDT sum: 17924  
np.round subDT sum:  16394  

or for `maxDT=4251` I got 5016 and 4252 respectively